### PR TITLE
Volunteer Dash Links Back to Adoption Map

### DIFF
--- a/apps/frontend/src/components/volunteerDashboard/VolunteerDashboard.tsx
+++ b/apps/frontend/src/components/volunteerDashboard/VolunteerDashboard.tsx
@@ -2,6 +2,7 @@ import { Box } from '@mui/material';
 import FacebookIcon from '@material-ui/icons/Facebook';
 import YouTubeIcon from '@material-ui/icons/YouTube';
 import generateInstagramIcon from './InstagramIcon';
+import { Link } from 'react-router-dom';
 
 const textStyles = {
   fontFamily: 'Montserrat, sans-serif',
@@ -84,7 +85,9 @@ function VolunteerDashboard() {
                 gap: '4%',
               }}
             >
-              <Box sx={{ ...boxStyles, width: '100%' }}>Adoption Map</Box>
+              <Link to="../" style={{ ...boxStyles, textDecoration: 'none', color: 'inherit', width: '100%', height: '100%' }}>
+                  <Box sx={{ ...boxStyles, width: '100%', height: '100%' }}>Adoption Map</Box>
+              </Link>
               <Box sx={{ ...boxStyles, width: '100%', padding: '3%' }}>
                 Maintenance Guide
               </Box>


### PR DESCRIPTION
### ℹ️ Issue

Closes [internal ticket]

### 📝 Description

Write a short summary of what you added. Why is it important? Any member of C4C should be able to read this and understand your contribution -- not just your team members.

Briefly list the changes made to the code:
1. Added a <Link> component wrapper around the Adoption Map Block on the Volunteer page.

### ✔️ Verification

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves.

Tested multiple times to ensure the "../" to= route for a Link component works.

Provide screenshots of any new components, styling changes, or pages. 

N/A

### 🏕️ (Optional) Future Work / Notes

Directory shortcuts using '.'s and '/'s for nested routes is helpful. Allows deep nesting without relying on potentially changing route name(s).
