### PR TITLE
Route Updates and 'Volunteer' page Links to 'My Adopted Green Infrastructure' page

### DIFF
--- a/apps/frontend/src/components/volunteerDashboard/VolunteerDashboard.tsx
+++ b/apps/frontend/src/components/volunteerDashboard/VolunteerDashboard.tsx
@@ -74,9 +74,11 @@ function VolunteerDashboard() {
               width: '100%',
             }}
           >
-            <Box sx={{ ...boxStyles, height: '50%', width: '100%' }}>
+          <Link to="my-adopted-gi" style={{ ...boxStyles, textDecoration: 'none', color: 'inherit', width: '100%', height: '50%' }}>
+            <Box sx={{ ...boxStyles, height: '100%', width: '100%'}}>
               My Adopted Green Infrastructure
             </Box>
+          </Link>
             <Box
               sx={{
                 display: 'flex',

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import MapPage from './pages/mapPage/MapPage';
+import MyAdoptedGIPage from './pages/myAdoptedGIPage/MyAdoptedGIPage';
+import VolunteerPage from './pages/volunteerPage/VolunteerPage';
 
 const queryClient = new QueryClient();
 
@@ -10,9 +12,11 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<MapPage />} />
-        </Routes>
+      <Routes>
+        <Route path="/" element={<MapPage />} />
+        <Route path="/volunteer" element={<VolunteerPage />} />
+        <Route path="/volunteer/my-adopted-gi" element={<MyAdoptedGIPage />} />
+      </Routes>
       </BrowserRouter>
     </QueryClientProvider>
   </React.StrictMode>,


### PR DESCRIPTION
ℹ️ Issue
Closes [internal ticket 2 for demo day]

📝 Description
Write a short summary of what you added. Why is it important? Any member of C4C should be able to read this and understand your contribution -- not just your team members.

Briefly list the changes made to the code:

1. Added a Link wrapper around the 'My Adopted GI' on the Volunteer page.
2. Updated main.tsx to accommodate the /volunteer and /volunteer/my-adopted-gi routes.

✔️ Verification
What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves.

Tested multiple times to ensure the routes worked as expected, going back and forth between main and the /volunteer/my-adopted-gi levels.

Provide screenshots of any new components, styling changes, or pages.

N/A

🏕️ (Optional) Future Work / Notes
1. Directory shortcuts using '.'s and '/'s for nested routes is helpful. Allows deep nesting without relying on potentially changing route name(s). 
2. Reminder --> If you are already under a nested route, say /volunteer, using <Link to="my-adopted-gi"> under that page will route to /volunteer/my-adopted-gi. (No starting slash will maintain your current pathing, but a starting slash (/) will be treated as absolute.