### PR TITLE
change backend site table name and column names

### DIFF
--- a/apps/backend/src/site/site.service.ts
+++ b/apps/backend/src/site/site.service.ts
@@ -5,7 +5,7 @@ import { DynamoDbService } from "../dynamodb";
 @Injectable()
 export class SiteService {
 
-    private readonly tableName = 'GIBostonSites';
+    private readonly tableName = 'greenInfraBostonSites';
 
     constructor(private readonly dynamoDbService: DynamoDbService) {}
 
@@ -16,7 +16,7 @@ export class SiteService {
     */
     public async getSite(siteId: number): Promise<SiteModel> {
         try{
-            const key = { 'Object ID?': { N: siteId } };
+            const key = { 'siteId': { S: siteId.toString() } };
             const data = await this.dynamoDbService.getItem(this.tableName, key);
             return(this.mapDynamoDBItemToSite(siteId, data));
         }  
@@ -28,16 +28,16 @@ export class SiteService {
     private mapDynamoDBItemToSite = (objectId: number, item: { [key: string]: any }): SiteModel => {
         return {
             siteID: objectId,
-            siteName: item["Asset Name"].S,
+            siteName: item["siteName"].S,
             siteStatus: SiteStatus.AVAILABLE, //placeholder until table is updated
-            assetType: item["Asset Type"].S,
-            symbolType: item["Symbol Type"].S,
-            siteLatitude: item["Lat"].S,
-            siteLongitude: item["Long"].S,
+            assetType: item["assetType"].S,
+            symbolType: item["symbolType"].S,
+            siteLatitude: item["siteLatitude"].S,
+            siteLongitude: item["siteLongitude"].S,
             dateAdopted: new Date(), //placeholder until table is updated
             maintenanceReports: [], //placeholder until table is updated
-            neighborhood: item["Neighborhood"].S,
-            address: item["Address"].S
+            neighborhood: item["neighborhood"].S,
+            address: item["address"].S
         };
     };
 


### PR DESCRIPTION
### ℹ️ Issue

Closes https://www.notion.so/mahekagg/GI-45-Fix-GET-site-by-ID-1258b3e6836e80c9a100e040177cbc58?pvs=4

### 📝 Description

Updated the backend to use the new Site table name and new column names.

### ✔️ Verification

![image](https://github.com/user-attachments/assets/462320c0-b1d7-4f06-b3cc-185a113de568)


### 🏕️ (Optional) Future Work / Notes

Does the "siteID" key in site.model.ts need to be updated to be of String type from a number to match the type on DynamoDB?