### PR TITLE
Ns get all sites by status

### DIFF
--- a/apps/backend/src/dynamodb.ts
+++ b/apps/backend/src/dynamodb.ts
@@ -1,4 +1,4 @@
-import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
+import { DynamoDBClient, GetItemCommand, ScanCommand } from "@aws-sdk/client-dynamodb";
 import { Injectable } from "@nestjs/common";
 
 @Injectable()
@@ -14,6 +14,23 @@ export class DynamoDbService {
       },
     });
   }
+
+  public async scanTable(tableName: string, filterExpression?: string, expressionAttributeValues?: { [key: string]: any }): Promise<any[]> {
+    const params = {
+      TableName: tableName,
+      FilterExpression: filterExpression,
+      ExpressionAttributeValues: expressionAttributeValues,
+    };
+
+    try {
+      const data = await this.dynamoDbClient.send(new ScanCommand(params));
+      return data.Items || [];
+    } catch (error) {
+      console.error('DynamoDB Scan Error:', error);
+      throw new Error(`Unable to scan table ${tableName}`);
+    }
+  }
+
 
   public async getItem(tableName: string, key: { [key: string]: any }): Promise<any> {
     const params = {

--- a/apps/backend/src/site/site.controller.ts
+++ b/apps/backend/src/site/site.controller.ts
@@ -19,10 +19,10 @@ export class SiteController {
     }  
 
     @Get()
-    public async getSitesByStatus(
+    public async getAllSitesByStatus(
         @Query("status") status: string
     ): Promise<SiteModel[]> {
-        return this.siteService.getSitesByStatus(status);
+        return this.siteService.getAllSitesByStatus(status);
     }
 
 

--- a/apps/backend/src/site/site.controller.ts
+++ b/apps/backend/src/site/site.controller.ts
@@ -2,6 +2,7 @@ import {
     Controller,
     Get,
     Param,
+    Query
 } from "@nestjs/common";
 import { SiteService } from "./site.service";
 import { SiteModel } from "./site.model";
@@ -16,6 +17,13 @@ export class SiteController {
     ): Promise<SiteModel> {
         return this.siteService.getSite(siteId);
     }  
+
+    @Get()
+    public async getSitesByStatus(
+        @Query("status") status: string
+    ): Promise<SiteModel[]> {
+        return this.siteService.getSitesByStatus(status);
+    }
 
 
 }

--- a/apps/backend/src/site/site.service.ts
+++ b/apps/backend/src/site/site.service.ts
@@ -5,7 +5,7 @@ import { DynamoDbService } from "../dynamodb";
 @Injectable()
 export class SiteService {
 
-    private readonly tableName = 'GIBostonSites';
+    private readonly tableName = 'greenInfraBostonSites';
 
     constructor(private readonly dynamoDbService: DynamoDbService) {}
 
@@ -23,6 +23,21 @@ export class SiteService {
         catch(e) {
             throw new Error("Unable to get site data: "+ e)
         }
+    }
+
+    public async getSitesByStatus(status: string): Promise<SiteModel[]> {
+        try {
+            const data = await this.dynamoDbService.scanTable(this.tableName, "Site Status = :status", { ":status": { S: status } });
+            const sites: SiteModel[] = [];
+            for (let i = 0; i < data.length; i++) {
+                sites.push(this.mapDynamoDBItemToSite(data[i]["Object ID?"].N, data[i]));
+            }
+            return sites;
+        }
+        catch(e) {
+            throw new Error("Unable to get site data: "+ e)
+        }
+
     }
 
     private mapDynamoDBItemToSite = (objectId: number, item: { [key: string]: any }): SiteModel => {

--- a/apps/backend/src/site/site.service.ts
+++ b/apps/backend/src/site/site.service.ts
@@ -27,11 +27,17 @@ export class SiteService {
 
     public async getSitesByStatus(status: string): Promise<SiteModel[]> {
         try {
-            const data = await this.dynamoDbService.scanTable(this.tableName, "Site Status = :status", { ":status": { S: status } });
+            const data = await this.dynamoDbService.scanTable(this.tableName, "siteStatus = :status", { ":status": { S: status } }  );
             const sites: SiteModel[] = [];
             for (let i = 0; i < data.length; i++) {
-                sites.push(this.mapDynamoDBItemToSite(data[i]["Object ID?"].N, data[i]));
+                try {
+                    sites.push(this.mapDynamoDBItemToSite(parseInt(data[i]["siteId"].S), data[i]));
+                } catch (error) {
+                    console.error('Error mapping site:', error, data[i]);
+                }
+
             }
+            console.log("Found " + sites.length + " sites with status \"" + status + "\"");
             return sites;
         }
         catch(e) {

--- a/apps/backend/src/site/site.service.ts
+++ b/apps/backend/src/site/site.service.ts
@@ -25,7 +25,7 @@ export class SiteService {
         }
     }
 
-    public async getSitesByStatus(status: string): Promise<SiteModel[]> {
+    public async getAllSitesByStatus(status: string): Promise<SiteModel[]> {
         try {
             const data = await this.dynamoDbService.scanTable(this.tableName, "siteStatus = :status", { ":status": { S: status } }  );
             const sites: SiteModel[] = [];

--- a/apps/backend/src/site/site.service.ts
+++ b/apps/backend/src/site/site.service.ts
@@ -5,7 +5,7 @@ import { DynamoDbService } from "../dynamodb";
 @Injectable()
 export class SiteService {
 
-    private readonly tableName = 'GIBostonSites';
+    private readonly tableName = 'greenInfraBostonSites';
 
     constructor(private readonly dynamoDbService: DynamoDbService) {}
 
@@ -16,7 +16,7 @@ export class SiteService {
     */
     public async getSite(siteId: number): Promise<SiteModel> {
         try{
-            const key = { 'Object ID?': { N: siteId } };
+            const key = { 'siteId': { S: siteId.toString() } };
             const data = await this.dynamoDbService.getItem(this.tableName, key);
             return(this.mapDynamoDBItemToSite(siteId, data));
         }  
@@ -28,16 +28,16 @@ export class SiteService {
     private mapDynamoDBItemToSite = (objectId: number, item: { [key: string]: any }): SiteModel => {
         return {
             siteID: objectId,
-            siteName: item["Asset Name"].S,
+            siteName: item["siteName"].S,
             siteStatus: SiteStatus.AVAILABLE, //placeholder until table is updated
-            assetType: item["Asset Type"].S,
-            symbolType: item["Symbol Type"].S,
-            siteLatitude: item["Lat"].S,
-            siteLongitude: item["Long"].S,
+            assetType: item["assetType"].S,
+            symbolType: item["symbolType"].S,
+            siteLatitude: item["siteLatitude"].S,
+            siteLongitude: item["siteLongitude"].S,
             dateAdopted: new Date(), //placeholder until table is updated
             maintenanceReports: [], //placeholder until table is updated
-            neighborhood: item["Neighborhood"].S,
-            address: item["Address"].S
+            neighborhood: item["neighborhood"].S,
+            address: item["address"].S
         };
     };
 


### PR DESCRIPTION
ℹ️ Issue
Closes https://www.notion.so/mahekagg/GI-41-GET-all-sites-by-status-11f8b3e6836e805f9162ef7f4d42f696?pvs=4

📝 Description
Added the get sites by status endpoint

Briefly list the changes made to the code:

- Added a function to the DynamoDB module to scan a table with a filter 
- Added a getAllSitesByStatus endpoint to the Sites module
(note: this could be performed more efficiently if we designate siteStatus as a global secondary index in dynamo, O(logn) instead of O(n) I think)

✔️ Verification
Ran the website locally and tested an "Available" sites query

<img width="1423" alt="Screenshot 2024-10-20 at 11 26 53 PM" src="https://github.com/user-attachments/assets/d232fd8e-c660-43c1-8ffb-eb8186b48e88">

