### PR TITLE
GI 42 get all sites by symbol type

### DIFF
--- a/apps/backend/src/dynamodb.ts
+++ b/apps/backend/src/dynamodb.ts
@@ -1,4 +1,4 @@
-import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
+import { DynamoDBClient, GetItemCommand, ScanCommand } from "@aws-sdk/client-dynamodb";
 import { Injectable } from "@nestjs/common";
 
 @Injectable()
@@ -14,6 +14,23 @@ export class DynamoDbService {
       },
     });
   }
+
+  public async scanTable(tableName: string, filterExpression?: string, expressionAttributeValues?: { [key: string]: any }): Promise<any[]> {
+    const params = {
+      TableName: tableName,
+      FilterExpression: filterExpression,
+      ExpressionAttributeValues: expressionAttributeValues,
+    };
+
+    try {
+      const data = await this.dynamoDbClient.send(new ScanCommand(params));
+      return data.Items || [];
+    } catch (error) {
+      console.error('DynamoDB Scan Error:', error);
+      throw new Error(`Unable to scan table ${tableName}`);
+    }
+  }
+
 
   public async getItem(tableName: string, key: { [key: string]: any }): Promise<any> {
     const params = {

--- a/apps/backend/src/dynamodb.ts
+++ b/apps/backend/src/dynamodb.ts
@@ -16,12 +16,17 @@ export class DynamoDbService {
   }
 
   public async scanTable(tableName: string, filterExpression?: string, expressionAttributeValues?: { [key: string]: any }): Promise<any[]> {
-    const params = {
+    // By default, scan the entire table
+    const params: any = {
       TableName: tableName,
-      FilterExpression: filterExpression,
-      ExpressionAttributeValues: expressionAttributeValues,
     };
-
+    // Conditionally add FilterExpression and ExpressionAttributeValues if they exist
+    if (filterExpression) {
+      params.FilterExpression = filterExpression;
+    }
+    if (expressionAttributeValues) {
+      params.ExpressionAttributeValues = expressionAttributeValues;
+    }
     try {
       const data = await this.dynamoDbClient.send(new ScanCommand(params));
       return data.Items || [];

--- a/apps/backend/src/site/site.controller.ts
+++ b/apps/backend/src/site/site.controller.ts
@@ -19,10 +19,10 @@ export class SiteController {
     }  
 
     @Get()
-    public async getSitesByStatus(
+    public async getAllSitesByStatus(
         @Query("status") status: string
     ): Promise<SiteModel[]> {
-        return this.siteService.getSitesByStatus(status);
+        return this.siteService.getAllSitesByStatus(status);
     }
 
 

--- a/apps/backend/src/site/site.controller.ts
+++ b/apps/backend/src/site/site.controller.ts
@@ -2,6 +2,7 @@ import {
     Controller,
     Get,
     Param,
+    Query
 } from "@nestjs/common";
 import { SiteService } from "./site.service";
 import { SiteModel } from "./site.model";
@@ -16,6 +17,13 @@ export class SiteController {
     ): Promise<SiteModel> {
         return this.siteService.getSite(siteId);
     }  
+
+    @Get()
+    public async getSitesByStatus(
+        @Query("status") status: string
+    ): Promise<SiteModel[]> {
+        return this.siteService.getSitesByStatus(status);
+    }
 
 
 }

--- a/apps/backend/src/site/site.controller.ts
+++ b/apps/backend/src/site/site.controller.ts
@@ -6,6 +6,7 @@ import {
 } from "@nestjs/common";
 import { SiteService } from "./site.service";
 import { SiteModel } from "./site.model";
+import { ApiQuery } from "@nestjs/swagger";
 
 @Controller("sites")
 export class SiteController {
@@ -19,10 +20,13 @@ export class SiteController {
     }  
 
     @Get()
-    public async getAllSitesByStatus(
-        @Query("status") status: string
+    @ApiQuery({ name: 'status', required: false }) // makes query parameter optional
+    @ApiQuery({ name: 'symbol-type', required: false })
+    public async getSites(
+        @Query("status") status?: string,
+        @Query("symbol-type") symbolType?: string
     ): Promise<SiteModel[]> {
-        return this.siteService.getAllSitesByStatus(status);
+        return this.siteService.getFilteredSites({ status, symbolType });
     }
 
 

--- a/apps/backend/src/site/site.service.ts
+++ b/apps/backend/src/site/site.service.ts
@@ -5,7 +5,7 @@ import { DynamoDbService } from "../dynamodb";
 @Injectable()
 export class SiteService {
 
-    private readonly tableName = 'GIBostonSites';
+    private readonly tableName = 'greenInfraBostonSites';
 
     constructor(private readonly dynamoDbService: DynamoDbService) {}
 
@@ -23,6 +23,21 @@ export class SiteService {
         catch(e) {
             throw new Error("Unable to get site data: "+ e)
         }
+    }
+
+    public async getSitesByStatus(status: string): Promise<SiteModel[]> {
+        try {
+            const data = await this.dynamoDbService.scanTable(this.tableName, "Site Status = :status", { ":status": { S: status } });
+            const sites: SiteModel[] = [];
+            for (let i = 0; i < data.length; i++) {
+                sites.push(this.mapDynamoDBItemToSite(data[i]["Object ID?"].N, data[i]));
+            }
+            return sites;
+        }
+        catch(e) {
+            throw new Error("Unable to get site data: "+ e)
+        }
+
     }
 
     private mapDynamoDBItemToSite = (objectId: number, item: { [key: string]: any }): SiteModel => {

--- a/apps/backend/src/site/site.service.ts
+++ b/apps/backend/src/site/site.service.ts
@@ -27,11 +27,17 @@ export class SiteService {
 
     public async getSitesByStatus(status: string): Promise<SiteModel[]> {
         try {
-            const data = await this.dynamoDbService.scanTable(this.tableName, "Site Status = :status", { ":status": { S: status } });
+            const data = await this.dynamoDbService.scanTable(this.tableName, "siteStatus = :status", { ":status": { S: status } }  );
             const sites: SiteModel[] = [];
             for (let i = 0; i < data.length; i++) {
-                sites.push(this.mapDynamoDBItemToSite(data[i]["Object ID?"].N, data[i]));
+                try {
+                    sites.push(this.mapDynamoDBItemToSite(parseInt(data[i]["siteId"].S), data[i]));
+                } catch (error) {
+                    console.error('Error mapping site:', error, data[i]);
+                }
+
             }
+            console.log("Found " + sites.length + " sites with status \"" + status + "\"");
             return sites;
         }
         catch(e) {

--- a/apps/backend/src/site/site.service.ts
+++ b/apps/backend/src/site/site.service.ts
@@ -25,7 +25,7 @@ export class SiteService {
         }
     }
 
-    public async getSitesByStatus(status: string): Promise<SiteModel[]> {
+    public async getAllSitesByStatus(status: string): Promise<SiteModel[]> {
         try {
             const data = await this.dynamoDbService.scanTable(this.tableName, "siteStatus = :status", { ":status": { S: status } }  );
             const sites: SiteModel[] = [];

--- a/apps/backend/src/site/site.service.ts
+++ b/apps/backend/src/site/site.service.ts
@@ -5,7 +5,7 @@ import { DynamoDbService } from "../dynamodb";
 @Injectable()
 export class SiteService {
 
-    private readonly tableName = 'GIBostonSites';
+    private readonly tableName = 'greenInfraBostonSites';
 
     constructor(private readonly dynamoDbService: DynamoDbService) {}
 
@@ -16,7 +16,7 @@ export class SiteService {
     */
     public async getSite(siteId: number): Promise<SiteModel> {
         try{
-            const key = { 'Object ID?': { N: siteId } };
+            const key = { 'siteId': { S: siteId.toString() } };
             const data = await this.dynamoDbService.getItem(this.tableName, key);
             return(this.mapDynamoDBItemToSite(siteId, data));
         }  
@@ -28,16 +28,16 @@ export class SiteService {
     private mapDynamoDBItemToSite = (objectId: number, item: { [key: string]: any }): SiteModel => {
         return {
             siteID: objectId,
-            siteName: item["Asset Name"].S,
+            siteName: item["siteName"].S,
             siteStatus: SiteStatus.AVAILABLE, //placeholder until table is updated
-            assetType: item["Asset Type"].S,
-            symbolType: item["Symbol Type"].S,
-            siteLatitude: item["Lat"].S,
-            siteLongitude: item["Long"].S,
+            assetType: item["assetType"].S,
+            symbolType: item["symbolType"].S,
+            siteLatitude: item["siteLatitude"].S,
+            siteLongitude: item["siteLongitude"].S,
             dateAdopted: new Date(), //placeholder until table is updated
             maintenanceReports: [], //placeholder until table is updated
-            neighborhood: item["Neighborhood"].S,
-            address: item["Address"].S
+            neighborhood: item["neighborhood"].S,
+            address: item["address"].S
         };
     };
 

--- a/apps/backend/src/site/site.service.ts
+++ b/apps/backend/src/site/site.service.ts
@@ -38,9 +38,13 @@ export class SiteService {
                 filterExpressionParts.push("symbolType = :symbolType");
                 expressionAttributeValues[":symbolType"] = { S: filters.symbolType };
             }
-            // if there are more than 1 filter, combine them all with AND
-            const filterExpression = filterExpressionParts.length > 0 ? filterExpressionParts.join(" AND ") : null;
-            const data = await this.dynamoDbService.scanTable(this.tableName, filterExpression, expressionAttributeValues);
+            const data = await this.dynamoDbService.scanTable(
+                this.tableName, 
+                // if there are filter expression parts, join them with "AND", otherwise pass undefined
+                filterExpressionParts.length > 0 ? filterExpressionParts.join(" AND ") : undefined, 
+                // if there are expression attribute values, pass them, otherwise pass undefined
+                Object.keys(expressionAttributeValues).length > 0 ? expressionAttributeValues : undefined
+            );
             const sites: SiteModel[] = [];
             for (let i = 0; i < data.length; i++) {
                 try {


### PR DESCRIPTION
ℹ️ Issue
Closes https://www.notion.so/mahekagg/GI-42-GET-all-sites-by-symbol-type-11f8b3e6836e8004bd0ec64edd35d58b?pvs=4

📝 Description
Added the get sites by symbol type endpoint.

Briefly list the changes made to the code:

- Merged the [get site by status](https://github.com/Code-4-Community/green-infrastructure/pull/39) and get site by symbol type into one endpoint which use a common filter function
- Added a getFilteredSites which filters the table based on the given parameters
- If no filters are given, return list of all rows

✔️ Verification
Ran the website locally and tested an "Available" status sites query:
![image](https://github.com/user-attachments/assets/a686f38b-1e9d-44d2-ac25-2b51c83d6626)

Tested "Other" symbol type query:
![image](https://github.com/user-attachments/assets/01595961-7414-4034-bbbe-45d0809e756b)

Tested "Available" + "Other" query:
![image](https://github.com/user-attachments/assets/5c825cb2-d42e-49bf-a3e0-d1f31333ebf4)

Tested "Available" + "Doesnt Exist" query:
![image](https://github.com/user-attachments/assets/ae6e6ab0-9cd3-42ce-b291-9927fe5e6b70)

Tested no filters query:
![image](https://github.com/user-attachments/assets/2c577b5c-24e8-427a-b2fb-30a8cf70b174)
