### PR TITLE
updated frontend elements for #37 & #38

### DIFF
--- a/apps/frontend/src/components/map/Map.tsx
+++ b/apps/frontend/src/components/map/Map.tsx
@@ -268,7 +268,7 @@ const Map: React.FC<MapProps> = ({
       <MapDiv
         id="map"
         ref={mapRef}
-        style={{ width: '100%', height: '495px' }}
+        style={{ width: '100%', height: '675px' }}
       />
       {showSignUp && <SignUpPage setShowSignUp={setShowSignUp} />}
     </div>

--- a/apps/frontend/src/pages/loginPage/loginPage.tsx
+++ b/apps/frontend/src/pages/loginPage/loginPage.tsx
@@ -1,13 +1,11 @@
 import { Button, Box, Image, Input, Text, Stack } from "@chakra-ui/react";
 import { Link } from "react-router-dom";
 import BostonImage from "../../assets/images/loginPageMedia/boston-pru.png"
-import AppleLogo from "../../assets/images/loginPageMedia/applelogo.png"
 import c4cLogo from '../../images/logos/c4cLogo.png';
 import cityOfBostonLogo from '../../images/logos/cityOfBostonLogo.png';
 
-
-
 // Using className specifications to track hiearchy !
+// Using className specifications to track hierarchy!
 export default function LoginPage() {
     return (
         <Box
@@ -24,72 +22,77 @@ export default function LoginPage() {
                 flexDirection="column"
                 alignItems='center'
                 justifyContent='flex-start'
-                marginTop="12rem"
+                height="100%"
+                overflowY="auto" // Enable vertical scrolling
             >
+                {/* Added margin-top only to logos to create spacing from the top */}
                 <Box 
-                className='logos'
-                 display="flex"
-                 alignItems='center'
-                  >
+                    className='logos'
+                    display="flex"
+                    alignItems='center'
+                    marginTop="4rem" // Keep margin for logo spacing
+                >
                     <img
-                    src={cityOfBostonLogo}
-                    style={{ marginTop: '12px', paddingRight: '15px' }}
+                        src={cityOfBostonLogo}
+                        style={{ paddingRight: '15px' }}
                     />
                     <div
-                    style={{
-                        borderLeft: '1px solid rgba(0, 0, 0, 1)',
-                        height: '55px',
-                        paddingRight: '15px',
-                    }}
+                        style={{
+                            borderLeft: '1px solid rgba(0, 0, 0, 1)',
+                            height: '55px',
+                            paddingRight: '15px',
+                        }}
                     />
                     <img src={c4cLogo} />
                 </Box>
+                
+                {/* The rest of the content should have no additional margin */}
                 <Box
-                className="loginCTA"
-                width='321px'
-                height='29px'
-                marginTop='4rem'
+                    className="loginCTA"
+                    width='321px'
+                    height='auto'
+                    marginTop='2rem' // Adjust margin for spacing below logos
                 >
                     <Text
-                    fontStyle="Montserrat"
-                    fontSize="24px"
-                    lineHeight="29.26px"
-                    fontWeight="600"
+                        fontStyle="Montserrat"
+                        fontSize="24px"
+                        lineHeight="29.26px"
+                        fontWeight="600"
                     >Welcome Back Volunteer!</Text>
                     <Text
-                    fontStyle="Montserrat"
-                    fontSize="14px"
-                    lineHeight="17.07px"
-                    fontWeight="300"
+                        fontStyle="Montserrat"
+                        fontSize="14px"
+                        lineHeight="17.07px"
+                        fontWeight="300"
                     >Continue adopting today!</Text>
-                        <Box 
+                    <Box 
                         className='primaryLoginOption'
                         width='305px'
-                        >
-                            <Stack spacing='1rem'> {/* Adjust the spacing value as needed */}
+                    >
+                        <Stack spacing='1rem'>
                             <Box>
-                                <Text mb={2} fontSize="sm" fontWeight="normal">Email Address</Text> {/* Adjust mb value as needed */}
+                                <Text mb={2} fontSize="sm" fontWeight="normal">Email Address</Text>
                                 <Input
-                                width="305px"
-                                height="33px"
-                                bg="#D9D9D9"
-                                borderRadius="10px"
-                                borderColor="#D9D9D9"
-                                _hover={{ borderColor: 'gray.300' }}
-                                _focus={{ borderColor: 'gray.500', boxShadow: '0 0 0 1px gray.500' }}
+                                    width="100%"
+                                    height="33px"
+                                    bg="#D9D9D9"
+                                    borderRadius="10px"
+                                    borderColor="#D9D9D9"
+                                    _hover={{ borderColor: 'gray.300' }}
+                                    _focus={{ borderColor: 'gray.500', boxShadow: '0 0 0 1px gray.500' }}
                                 />
                             </Box>
                             <Box>
-                                <Text mb={2} fontSize="sm" fontWeight="normal">Password</Text> {/* Adjust mb value as needed */}
+                                <Text mb={2} fontSize="sm" fontWeight="normal">Password</Text>
                                 <Input
-                                width="305px"
-                                height="33px"
-                                bg="#D9D9D9"
-                                type="password"
-                                borderRadius="10px"
-                                borderColor="#D9D9D9"
-                                _hover={{ borderColor: 'gray.300' }}
-                                _focus={{ borderColor: 'gray.500', boxShadow: '0 0 0 1px gray.500' }}
+                                    width="100%"
+                                    height="33px"
+                                    bg="#D9D9D9"
+                                    type="password"
+                                    borderRadius="10px"
+                                    borderColor="#D9D9D9"
+                                    _hover={{ borderColor: 'gray.300' }}
+                                    _focus={{ borderColor: 'gray.500', boxShadow: '0 0 0 1px gray.500' }}
                                 />
                             </Box>
                             <Button
@@ -106,70 +109,20 @@ export default function LoginPage() {
                                 display="block"
                                 width="100%"
                                 textAlign="center"
-                                _hover={{ textDecoration: 'none' }} // Removes underline on hover
-                                textDecoration="none" // Removes underline
-                                color="current" // Ensures the button text uses the current font color
-                                >
+                                _hover={{ textDecoration: 'none' }}
+                                textDecoration="none"
+                                color="current"
+                            >
                                 Sign in
-                                </Button>
-                            </Stack>
-                        </Box>
-                        <Box className="orOptions" display="flex" alignItems="center"margin="1rem">
-                            <Box flex={1} height="1px" bg="black" mr={4} />
-                            <Text mt={6} mx={4}>or</Text> {/* mx is shorthand for margin on the x-axis (left and right) */}
-                            <Box flex={1} height="1px" bg="black" ml={4} mr={12}/>
-                            </Box>
-                            { /* */}
-
-                </Box>
-                <Box 
-                className="big-tech-login"
-                display="flex"
-                flexDirection="column"
-                marginTop="20rem"
-                >
-                <Button
-                                bg="#D9D9D9"
-                                borderRadius="10px"
-                                borderColor="#D9D9D9"
-                                fontWeight='300'
-                                fontSize='14px'
-                                fontStyle='Montserrat'
-                                lineHeight='17.07px'
-                                marginTop="2rem"
-                                width="300px"
-                            >
-                                Continue with Apple
                             </Button>
-                            <Button
-                                bg="#D9D9D9"
-                                borderRadius="10px"
-                                borderColor="#D9D9D9"
-                                fontWeight='300'
-                                fontSize='14px'
-                                fontStyle='Montserrat'
-                                lineHeight='17.07px'
-                                marginTop="2rem"
-                            >
-                                Continue with Facebook
-                            </Button>
-                            <Button
-                                bg="#D9D9D9"
-                                borderRadius="10px"
-                                borderColor="#D9D9D9"
-                                fontWeight='300'
-                                fontSize='14px'
-                                fontStyle='Montserrat'
-                                lineHeight='17.07px'
-                                marginTop="2rem"
-                            >
-                                Continue with Google
-                            </Button>
+                        </Stack>
+                    </Box>
                 </Box>
             </Box>
             <Box
                 className='media-side'
                 width="50%"
+                height="100%"
             >
                 <Image
                     src={BostonImage}


### PR DESCRIPTION
### ℹ️ Issue

Closes GI-37: Modify login page design & GI-38: Fix issue with some pop-up boxes being cut off

### 📝 Description
GI-37: I removed the items below the --or-- line including the or itself within the login page design. I am sure we have not implemented features to connect their Apple or Facebook accounts just yet. This is important as we need to make sure our volunteer login experience is as seamlessly as it can be and as easy to access with just an email address and password.
Not to mention, it also ensures a nicer page design where the users can visibly see all aspects of the login and not have to scroll down to find the sign-in buttons or other features. I made it so that even if the user zooms in a little bit, the login or user media side still looks formally well-fitted within the box.

GI-38: I increased the boundary of the map so that our outlier G.I. features that are at the top of the page for example can be seen fully and not cut off. Now, any G.I. features that the volunteer clicks on is able to be fully seen and this ensures the volunteers can see the G.I. features' name, location, status, feature type, etc. This is important as we want to make sure the volunteer knows as much as they can about the G.I. feature before they adopt it. 

Briefly list the changes made to the code:
1. Modified the login page design to be centered and removed anything below the sign-in button.
2. Modified the main page design to fit G.I features pop-up boxes wherever the user is on the map. 

### ✔️ Verification

Ran the frontend side through the terminal (nx serve green-infrastructure-frontend) and tested out the G.I. features by clicking the outermost G.I. features without any zoom into the map. I also zoomed in twice for the login page design to ensure the logos and sign-ins are centered and well formatted. 

<img width="503" alt="image" src="https://github.com/user-attachments/assets/7e5544cb-8093-4fab-b841-793cf15e71b8">

<img width="658" alt="Screenshot 2024-10-21 181217" src="https://github.com/user-attachments/assets/b510f3ab-9a3e-42d9-a74c-639c9c2b727e">


### 🏕️ (Optional) Future Work / Notes

When the user zooms in a lot, it can mess up the logo and page design a bit too much beyond our styling skills. 
