### PR TITLE
Refactor get sites by status and symbol into 2 separate endpoints

### DIFF
--- a/apps/backend/src/site/site.controller.ts
+++ b/apps/backend/src/site/site.controller.ts
@@ -48,15 +48,7 @@ export class SiteController {
         return this.siteService.postSite(siteData);
     }
 
-    @Get()
-    @ApiQuery({ name: 'status', required: false }) // makes query parameter optional
-    @ApiQuery({ name: 'symbol-type', required: false })
-    public async getSites(
-        @Query("status") status?: string,
-        @Query("symbol-type") symbolType?: string
-    ): Promise<SiteModel[]> {
-        return this.siteService.getFilteredSites({ status, symbolType });
-    }
+ 
 
 
 

--- a/apps/backend/src/site/site.controller.ts
+++ b/apps/backend/src/site/site.controller.ts
@@ -2,7 +2,8 @@ import {
     Controller,
     Get,
     Param,
-    Query
+    Query,
+    Delete
 } from "@nestjs/common";
 import { SiteService } from "./site.service";
 import { SiteModel } from "./site.model";
@@ -12,6 +13,26 @@ import { ApiQuery } from "@nestjs/swagger";
 export class SiteController {
     constructor(private siteService: SiteService) {}
 
+    @Get("/status/")
+    @ApiQuery({ name: "status", required: true })
+    public async getSitesByStatus(
+        @Query('status') status: string        
+    ): Promise<SiteModel[]> {
+        console.log("status: ", status);
+        return this.siteService.getSitesByStatus(status);
+    }
+
+
+    
+    @Get("/symbolType/")
+    @ApiQuery({ name: "symbolType", required: true })
+    public async getSitesBySymbolType(
+        @Query('symbolType') symbolType: string
+    ): Promise<SiteModel[]> {
+        return this.siteService.getSitesBySymbolType(symbolType);
+    }
+
+
     @Get(":id")
     public async getSite(
         @Param("id") siteId: number
@@ -19,15 +40,10 @@ export class SiteController {
         return this.siteService.getSite(siteId);
     }  
 
-    @Get()
-    @ApiQuery({ name: 'status', required: false }) // makes query parameter optional
-    @ApiQuery({ name: 'symbol-type', required: false })
-    public async getSites(
-        @Query("status") status?: string,
-        @Query("symbol-type") symbolType?: string
-    ): Promise<SiteModel[]> {
-        return this.siteService.getFilteredSites({ status, symbolType });
-    }
+ 
+
+
+
 
 
 }

--- a/apps/backend/src/site/site.service.ts
+++ b/apps/backend/src/site/site.service.ts
@@ -25,26 +25,9 @@ export class SiteService {
         }
     }
 
-    public async getFilteredSites(filters: { status?: string, symbolType?: string }): Promise<SiteModel[]> {
+    public async getSitesByStatus(status: string): Promise<SiteModel[]> {
         try {
-            const filterExpressionParts = [];
-            const expressionAttributeValues: { [key: string]: any } = {};
-            // add filters based on provided values
-            if (filters.status) {
-                filterExpressionParts.push("siteStatus = :status");
-                expressionAttributeValues[":status"] = { S: filters.status };
-            }
-            if (filters.symbolType) {
-                filterExpressionParts.push("symbolType = :symbolType");
-                expressionAttributeValues[":symbolType"] = { S: filters.symbolType };
-            }
-            const data = await this.dynamoDbService.scanTable(
-                this.tableName, 
-                // if there are filter expression parts, join them with "AND", otherwise pass undefined
-                filterExpressionParts.length > 0 ? filterExpressionParts.join(" AND ") : undefined, 
-                // if there are expression attribute values, pass them, otherwise pass undefined
-                Object.keys(expressionAttributeValues).length > 0 ? expressionAttributeValues : undefined
-            );
+            const data = await this.dynamoDbService.scanTable(this.tableName, "siteStatus = :status", { ":status": { S: status } }  );
             const sites: SiteModel[] = [];
             for (let i = 0; i < data.length; i++) {
                 try {
@@ -52,13 +35,38 @@ export class SiteService {
                 } catch (error) {
                     console.error('Error mapping site:', error, data[i]);
                 }
+
             }
-            console.log(`Found ${sites.length} sites matching the criteria.`);
+            console.log("Found " + sites.length + " \"" + status + "' sites");
             return sites;
-        } catch (e) {
-            throw new Error("Unable to get site data: " + e);
         }
+        catch(e) {
+            throw new Error("Unable to get site by status: "+ e)
+        }
+
     }
+
+    public async getSitesBySymbolType(symbolType: string): Promise<SiteModel[]> {
+        try {
+            const data = await this.dynamoDbService.scanTable(this.tableName, "symbolType = :symbolType", { ":symbolType": { S: symbolType } }  );
+            const sites: SiteModel[] = [];
+            for (let i = 0; i < data.length; i++) {
+                try {
+                    sites.push(this.mapDynamoDBItemToSite(parseInt(data[i]["siteId"].S), data[i]));
+                } catch (error) {
+                    console.error('Error mapping site:', error, data[i]);
+                }
+
+            }
+            console.log("Found " + sites.length + " \"" + symbolType + "' sites");
+            return sites;
+        }
+        catch(e) {
+            throw new Error("Unable to get site by symbol: "+ e)
+        }
+
+    }
+
 
     private mapDynamoDBItemToSite = (objectId: number, item: { [key: string]: any }): SiteModel => {
         return {


### PR DESCRIPTION
ℹ️ Issue
Fixes GI-41 and GI-42

📝 Description
Refactor the get all sites by status and symbol functionality into 2 endpoints

Briefly list the changes made to the code:
Instead of a single sites endpoint with 2 optional parameters, I made 2 separate endpoints as described in the endpoints google doc

✔️ Verification
Ran the website locally and tested an "Available" status query and "Other" symbol query
<img width="1269" alt="Screenshot 2024-10-21 at 7 59 10 PM" src="https://github.com/user-attachments/assets/30d53669-9fec-4f1d-90e6-72e8d648c301">
<img width="1279" alt="Screenshot 2024-10-21 at 7 59 40 PM" src="https://github.com/user-attachments/assets/a1183759-7099-4939-b5fd-bcef6ef65128">
