### PR TITLE
Add delete sites by ID endpoint 

### DIFF
--- a/apps/backend/src/dynamodb.ts
+++ b/apps/backend/src/dynamodb.ts
@@ -1,4 +1,4 @@
-import { DynamoDBClient, GetItemCommand, ScanCommand } from "@aws-sdk/client-dynamodb";
+import { DynamoDBClient, GetItemCommand, ScanCommand, DeleteItemCommand} from "@aws-sdk/client-dynamodb";
 import { Injectable } from "@nestjs/common";
 
 @Injectable()
@@ -13,6 +13,21 @@ export class DynamoDbService {
         secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
       },
     });
+  }
+
+
+  public async deleteItem (tableName: string, key: { [key: string]: any }): Promise<void> {
+    const params = {
+      TableName: tableName,
+      Key: key,
+    };
+
+    try {
+      await this.dynamoDbClient.send(new DeleteItemCommand(params));
+    } catch (error) {
+      console.error('DynamoDB DeleteItem Error:', error);
+      throw new Error(`Unable to delete item from ${tableName}`);
+    }
   }
 
   public async scanTable(tableName: string, filterExpression?: string, expressionAttributeValues?: { [key: string]: any }): Promise<any[]> {

--- a/apps/backend/src/site/site.controller.ts
+++ b/apps/backend/src/site/site.controller.ts
@@ -30,8 +30,8 @@ export class SiteController {
         return this.siteService.getFilteredSites({ status, symbolType });
     }
 
-    @Delete(":id")
-    public async deleteSite(
+    @Delete("/deleteSite/:id")
+    public async deleteSiteById(
         @Param("id") siteId: number
     ): Promise<void> {
         return this.siteService.deleteSite(siteId);

--- a/apps/backend/src/site/site.controller.ts
+++ b/apps/backend/src/site/site.controller.ts
@@ -1,5 +1,6 @@
 import {
     Controller,
+    Delete,
     Get,
     Param,
     Query
@@ -27,6 +28,13 @@ export class SiteController {
         @Query("symbol-type") symbolType?: string
     ): Promise<SiteModel[]> {
         return this.siteService.getFilteredSites({ status, symbolType });
+    }
+
+    @Delete(":id")
+    public async deleteSite(
+        @Param("id") siteId: number
+    ): Promise<void> {
+        return this.siteService.deleteSite(siteId);
     }
 
 

--- a/apps/backend/src/site/site.service.ts
+++ b/apps/backend/src/site/site.service.ts
@@ -60,6 +60,16 @@ export class SiteService {
         }
     }
 
+    public async deleteSite(siteId: number): Promise<void> {
+        try {
+            const key = { 'siteId': { S: siteId.toString() } };
+            await this.dynamoDbService.deleteItem(this.tableName, key);
+            console.log(`Deleted site with id ${siteId}`);
+        } catch (e) {
+            throw new Error("Unable to delete site data: " + e);
+        }
+    }
+
     private mapDynamoDBItemToSite = (objectId: number, item: { [key: string]: any }): SiteModel => {
         return {
             siteID: objectId,


### PR DESCRIPTION
ℹ️ Issue
Closes https://www.notion.so/mahekagg/GI-46-DELETE-site-by-ID-1268b3e6836e8034b6eefe1b65e60349?pvs=4

📝 Description
Added an endpoint for deleting a site by ID

Briefly list the changes made to the code:
- Added delete site by ID endpoint
- Added delete item function to DynamoDB module

✔️ Verification
Created a site on AWS console and then deleted it with endpoint

<img width="1026" alt="Screenshot 2024-10-26 at 7 37 12 PM" src="https://github.com/user-attachments/assets/7351b354-649c-41be-9325-d8df513bed86">
<img width="1416" alt="Screenshot 2024-10-26 at 7 37 27 PM" src="https://github.com/user-attachments/assets/44da26ea-6094-406a-bf4c-2edbe1cdf3b3">
<img width="1029" alt="Screenshot 2024-10-26 at 7 37 35 PM" src="https://github.com/user-attachments/assets/564549c2-db11-48f3-92c9-0e4a9482c137">


