### PR TITLE
Dl get site Ids per user

### DIFF
--- a/apps/backend/src/user/user.controller.ts
+++ b/apps/backend/src/user/user.controller.ts
@@ -19,6 +19,10 @@ export class UserController {
         ): Promise<UserModel> {
             return this.userService.getUser(userId);
         }
-
+    
+    @Get(":id/sites")
+    public async getUserSites(@Param("id") userId?: number): Promise<any> {
+        return this.userService.getUserTables(userId);
+    }
 
 }

--- a/apps/backend/src/user/user.service.ts
+++ b/apps/backend/src/user/user.service.ts
@@ -36,6 +36,22 @@ export class UserService {
 
     }
 
+    public async getUserTables(userId: number): Promise<Array<number>> {
+        try {
+            const key = { 'userId' : {N: userId.toString()}};
+            const data = await this.dynamoDbService.getItem(this.tableName, key);
+            if (!data) {
+                throw new Error(`No user found with id: ${userId}`);
+            }
+            console.log(data);
+            const siteIds = data["siteIds"].L.map(item => Number(item.N));
+            return siteIds;
+        } 
+        catch(e) {
+            throw new Error(`Error fetching data for user with id: ${userId}: ${e.message}`);
+        }
+    }
+
 
     /**
      * Maps a user's data from DynamoDB to a UserModel object.
@@ -47,7 +63,6 @@ export class UserService {
     private mapDynamoDBItemToUserModel(objectId: number, data: {[key: string]: any}): UserModel {
 
         const siteIds = data["siteIds"]?.NS?.map(Number) ?? [];
-
 
         return {
             userID: objectId,
@@ -62,7 +77,5 @@ export class UserService {
             status: data['status'].S
         };
     }
-
-
 
 }


### PR DESCRIPTION
# Changes

Note: should merge GI-35 before this ticket.

Add endpoint to get list of siteIds for a given userId.

Endpoint `/user/{id}/sites`

## Testing

Tested with postman, manually edited user 0 to have some test siteIds.

![test](https://github.com/user-attachments/assets/c454a437-e4bb-463f-b079-b674fb01705f)

Note: expects siteIDs in database to be list of numbers:

![site ids](https://github.com/user-attachments/assets/21c5dcae-734b-4c98-afa5-6347d6251144)