### PR TITLE
add put endpoint to update application status to Denied

### DIFF
--- a/apps/backend/src/applications/applications.controller.ts
+++ b/apps/backend/src/applications/applications.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Put, Param, Body } from '@nestjs/common';
+import { Controller, Get, Put, Param, Query  } from '@nestjs/common';
 import { ApplicationsService } from './applications.service';
 import { ApplicationsModel } from './applications.model';
 import { ApplicationStatus } from './applications.model';
@@ -12,24 +12,16 @@ export class ApplicationsController {
     return this.applicationsService.getApplications();
   }
 
-  @Put('applicationStatus/:appId')
+  @Put('editApplication/:appId')
   public async changeApplicationStatus(
     @Param('appId') appId: number,
-    @Body('appStatus') appStatus: ApplicationStatus,
+    @Query('applicationStatus') appStatus: ApplicationStatus
   ): Promise<ApplicationsModel> {
     // Check if the provided appStatus is a valid enum value
     if (!Object.values(ApplicationStatus).includes(appStatus)) {
       throw new Error(`Invalid application status: ${appStatus}`);
     }
 
-    const applications = await this.applicationsService.getApplications();
-
-    const appToModify = applications.find((app) => app.appId === appId);
-
-    if (appToModify) {
-      appToModify.status = appStatus;
-    }
-
-    return appToModify;
+    return this.applicationsService.updateApplicationStatus(appId, appStatus);
   }
 }

--- a/apps/backend/src/applications/applications.model.ts
+++ b/apps/backend/src/applications/applications.model.ts
@@ -15,5 +15,5 @@ export type ApplicationsModel = {
 export enum ApplicationStatus {
   APPROVED = 'Approved',
   PENDING = 'Pending',
-  REJECTED = 'Rejected',
+  DENIED = 'Denied',
 }

--- a/apps/backend/src/applications/applications.service.ts
+++ b/apps/backend/src/applications/applications.service.ts
@@ -33,14 +33,13 @@ export class ApplicationsService {
     appStatus: ApplicationStatus,
   ): Promise<ApplicationsModel> {
     try {
-      const key = { 'Object ID?': { N: appId } };
+      const key = { 'appId': { N: appId } };
       const application = await this.dynamoDbService.updateItem(
         this.tableName,
         key,
         appStatus,
       );
-
-      return application;
+      return this.mapDynamoDBItemToApplication(application);
     } catch (e) {
       throw new Error('Unable to update application status: ' + e);
     }

--- a/apps/backend/src/applications/applications.service.ts
+++ b/apps/backend/src/applications/applications.service.ts
@@ -34,12 +34,19 @@ export class ApplicationsService {
   ): Promise<ApplicationsModel> {
     try {
       const key = { 'appId': { N: appId } };
-      const application = await this.dynamoDbService.updateItem(
+      const application = await this.dynamoDbService.getItem(
+        this.tableName,
+        key,
+      );
+      if (!application) {
+        throw new Error('Application not found');
+      }
+      const updatedApplication = await this.dynamoDbService.updateItem(
         this.tableName,
         key,
         appStatus,
       );
-      return this.mapDynamoDBItemToApplication(application);
+      return this.mapDynamoDBItemToApplication(updatedApplication);
     } catch (e) {
       throw new Error('Unable to update application status: ' + e);
     }

--- a/apps/backend/src/dynamodb.ts
+++ b/apps/backend/src/dynamodb.ts
@@ -136,11 +136,18 @@ export class DynamoDbService {
     const params = {
       TableName: tableName,
       Key: key,
-      UpdateExpression: `SET status = ${status}`,
+      UpdateExpression: 'SET #status = :status',
+      ExpressionAttributeNames: {
+        '#status': 'status',
+      },
+      ExpressionAttributeValues: {
+        ':status': { S: status },
+      },
       ReturnValue: 'ALL_NEW',
     };
     const command = new UpdateItemCommand(params);
-    const result = await this.dynamoDbClient.send(command);
-    return result.Attributes;
+    await this.dynamoDbClient.send(command);
+    const result = this.getItem(tableName, key);
+    return result;
   }
 }


### PR DESCRIPTION
### ℹ️ Issue

Closes https://www.notion.so/mahekagg/GI-55-PUT-endpoint-to-set-application-status-to-Denied-12d8b3e6836e80399baaec22346de8c1?pvs=4

### 📝 Description

Created/modified the put endpoint in this [PR](https://github.com/Code-4-Community/green-infrastructure/pull/44) to be able to set an application's status to any valid status (Pending, Accepted, or Denied).

Briefly list the changes made to the code:
1. Updated the endpoint name and query parameters to match doc specifications
2. Updated backend application status enum 'Rejected' to 'Denied'
3. Updated updateItem method to wrap 'status' in an ExpressionAttributeNames/ExpressionAttributeValues so that it can be used as a key without Dynamo getting angry

### ✔️ Verification

Before:
![image](https://github.com/user-attachments/assets/7008cc82-6d07-4f6b-aa93-ff55aeeb187e)
Postman:
![image](https://github.com/user-attachments/assets/e42fa840-e151-4a7f-a5b8-d3eb62f63877)
After:
![image](https://github.com/user-attachments/assets/4f9883aa-a6b4-47c7-ba6e-55bdb602b1a9)


