### PR TITLE
add edit users endpoint

### DIFF
--- a/apps/backend/src/dynamodb.ts
+++ b/apps/backend/src/dynamodb.ts
@@ -5,6 +5,7 @@ import {
   DeleteItemCommand,
   PutItemCommand,
   UpdateItemCommand,
+  UpdateItemCommandInput
 } from '@aws-sdk/client-dynamodb';
 import { Injectable, Put } from '@nestjs/common';
 import { table } from 'console';
@@ -143,4 +144,43 @@ export class DynamoDbService {
     const result = await this.dynamoDbClient.send(command);
     return result.Attributes;
   }
+
+  public async updateItemWithExpression(
+    tableName: string,
+    key: { [key: string]: any },
+    updateExpression: string,
+    expressionAttributeValues?: Record<string, any>,
+    expressionAttributeNames?: Record<string, string>,
+): Promise<any> {
+    const params: UpdateItemCommandInput = {
+        TableName: tableName,
+        Key: key,
+        UpdateExpression: updateExpression,
+        ReturnValues: 'ALL_NEW',
+    };
+
+
+    if (expressionAttributeNames) {
+        params.ExpressionAttributeNames = expressionAttributeNames;
+    }
+    
+
+    if (expressionAttributeValues) {
+        params.ExpressionAttributeValues = expressionAttributeValues;
+    }
+
+    try {
+        const command = new UpdateItemCommand(params);
+        const result = await this.dynamoDbClient.send(command);
+        return result.Attributes;
+    } catch (error) {
+        // Log detailed error info
+        console.error("DynamoDB Update Error:", error);
+        throw new Error(`Failed to update item in DynamoDB: ${error.message}`);
+    }
+
+ 
+}
+
+
 }

--- a/apps/backend/src/user/user.controller.ts
+++ b/apps/backend/src/user/user.controller.ts
@@ -2,9 +2,11 @@ import {
     Controller,
     Get,
     Param,
+    Put,
+    Body
 } from "@nestjs/common";
 import { UserService } from "./user.service";
-import { UserModel } from "./user.model";
+import { UserModel, EditUserModel } from "./user.model";
 
 /**
  * The controller for user endpoints.
@@ -24,6 +26,14 @@ export class UserController {
     @Get(":id/sites")
     public async getUserSites(@Param("id") userId?: number): Promise<any> {
         return this.userService.getUserTables(userId);
+    }
+
+    @Put("/editUser/:id")
+    public async editUser(
+        @Param("id") userId?: number, 
+        @Body() editUserModel?: EditUserModel
+    ): Promise<UserModel> {
+        return this.userService.editUser(userId, editUserModel);
     }
 
 

--- a/apps/backend/src/user/user.model.ts
+++ b/apps/backend/src/user/user.model.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 
 /**
  * A DTO representing a user.
@@ -14,6 +15,20 @@ export type UserModel = {
     role: Role,
     status: UserStatus
 };
+
+export class EditUserModel {
+    @ApiProperty({ required: false, description: 'First name of the user' })
+    firstName?: string;
+    @ApiProperty({ required: false, description: 'Last name of the user' })
+    lastName?: string;
+    @ApiProperty({ required: false, description: 'Phone number of the user' })
+    phoneNumber?: string;
+    @ApiProperty({ required: false, description: 'Site ID to append to siteIds' })
+    siteId?: number;
+    @ApiProperty({ required: false, description: 'Status of the user' })
+    status?: string;
+}
+
 
 export enum Role {
     VOLUNTEER = "Volunteer",

--- a/apps/backend/src/user/user.service.ts
+++ b/apps/backend/src/user/user.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from "@nestjs/common";
-import { UserModel } from "./user.model";
+import { UserModel, EditUserModel } from "./user.model";
 import { DynamoDbService } from "../dynamodb";
 import {UserStatus} from "./user.model";
 import {Role} from "./user.model";
+import { stat } from "fs";
 
 @Injectable()
 export class UserService {
@@ -53,6 +54,85 @@ export class UserService {
         }
     }
 
+    public async editUser(userId: number, model :EditUserModel): Promise<any> {
+
+        try {
+            // A list of commands for each edit, only adds if exists
+            const commands = [];
+            const expressionAttributeValues :Record<string,any> = {};
+            const expressionAttributeNames: Record<string, string> = {}; // Added for aliases
+
+            const originalUser = await this.getUser(userId);
+
+
+
+            if (model.firstName) {
+                commands.push(`firstName = :firstName`);
+                expressionAttributeValues[":firstName"] = { S: model.firstName };
+            }
+    
+            if (model.lastName) {
+                commands.push(`lastName = :lastName`);
+                expressionAttributeValues[":lastName"] = { S: model.lastName };
+            }
+    
+            if (model.phoneNumber) {
+                commands.push(`phoneNumber = :phoneNumber`);
+                expressionAttributeValues[":phoneNumber"] = { S: model.phoneNumber };
+            }
+    
+            if (model.siteId) {
+                // Ensure siteId is treated as a string
+                const siteIdStr = model.siteId.toString();
+          
+                // Use list_append to add the new siteId to the siteIds list
+                commands.push(`siteIds = list_append(siteIds, :siteId)`);
+                expressionAttributeValues[":siteId"] = { L: [{ N: siteIdStr }] };
+          
+                // Check if siteId exists in greenInfraBostonSites using getItem
+                const siteKey = { siteId: { S: siteIdStr } };
+                const siteCheckResult = await this.dynamoDbService.getItem('greenInfraBostonSites', siteKey);
+
+                if(originalUser.siteIds.includes(model.siteId)) {
+                    return {statusCode: 400, message: "Site already exists in user's siteIds"};
+                }
+          
+                if (!siteCheckResult) {
+                    return {statusCode: 400, message: "Site does not exist"};
+                }
+              }
+
+              if (model.status) {
+                commands.push(`#s = :status`);
+                expressionAttributeValues[":status"] = { S: model.status };
+                expressionAttributeNames["#s"] = "status"; // Define the alias
+              }
+
+
+            // Make sure commands aren't empty
+            if (commands.length === 0) {
+                throw new Error("No fields to update");
+            }
+
+
+            // Combine into one update expression and update the user 
+            const updateExpr = `SET ${commands.join(", ")}`;
+            const key = { 'userId' : {N: userId.toString()}};
+            const data = await this.dynamoDbService.updateItemWithExpression(this.tableName, key, updateExpr,expressionAttributeValues, expressionAttributeNames)
+  
+            const result = await this.getUser(userId);
+            
+
+            if (!data) {
+                return {statusCode: 400, message: "No user found with id: " + userId};
+            }
+            return result;
+        } catch(e) {
+            throw new Error(`Error updating data for user with id: ${userId}: ${e.message}`);
+        }            
+    }
+        
+
 
     /**
      * Maps a user's data from DynamoDB to a UserModel object.
@@ -63,7 +143,7 @@ export class UserService {
      */
     private mapDynamoDBItemToUserModel(objectId: number, data: {[key: string]: any}): UserModel {
 
-        const siteIds = data["siteIds"]?.NS?.map(Number) ?? [];
+        const siteIds = data["siteIds"].L.map(item => Number(item.N)) ?? [];
 
 
         return {
@@ -79,6 +159,8 @@ export class UserService {
             status: data['status'].S
         };
     }
+
+
 
 
 }


### PR DESCRIPTION
ℹ️ Issue
Closes https://www.notion.so/mahekagg/GI-53-PUT-endpoint-to-set-site-status-to-Adopted-12d8b3e6836e8052a7abc011e9deada7?pvs=4

📝 Description
Adds an endpoint to edit users as described in the endpoints doc

Verification 

<img width="1253" alt="Screenshot 2024-11-12 at 1 25 04 AM" src="https://github.com/user-attachments/assets/87c2ef6b-02ba-4149-8377-f3615e289dcc">

Forgot to take a picture before but it edited it correctly
<img width="1373" alt="Screenshot 2024-11-12 at 1 25 57 AM" src="https://github.com/user-attachments/assets/689ed156-73b4-4b0f-a343-136082442fda">


<img width="1266" alt="Screenshot 2024-11-12 at 1 30 32 AM" src="https://github.com/user-attachments/assets/0a920f17-4287-4462-952c-f110164c2d67">

Also gives error if user or site does not exist
Also returns all of user's attributes on success
