### PR TITLE
Populate map using get all sites

### DIFF
--- a/apps/backend/src/site/site.controller.ts
+++ b/apps/backend/src/site/site.controller.ts
@@ -17,6 +17,11 @@ import { ApiQuery } from "@nestjs/swagger";
 export class SiteController {
     constructor(private siteService: SiteService) {}
 
+    @Get()
+    public async getAllSites(): Promise<SiteModel[]> {
+        return this.siteService.getAllSites();
+    }
+
     @Get("/status/")
     @ApiQuery({ name: "status", required: true })
     public async getSitesByStatus(
@@ -44,7 +49,7 @@ export class SiteController {
         return this.siteService.getSite(siteId);
     }  
 
-    @Post()
+    @Post("/addSite")
     public async postSite(@Body() siteData: NewSiteInput) {
         return this.siteService.postSite(siteData);
     }

--- a/apps/backend/src/site/site.service.ts
+++ b/apps/backend/src/site/site.service.ts
@@ -25,6 +25,29 @@ export class SiteService {
             throw new Error("Unable to get site data: "+ e)
         }
     }
+
+    /**
+     * Scans the entire sites table and returns all rows.
+     * @returns the full list of sites
+     */
+    public async getAllSites(): Promise<SiteModel[]> {
+        try {
+            const data = await this.dynamoDbService.scanTable(this.tableName);
+            const sites: SiteModel[] = [];
+            for (let i = 0; i < data.length; i++) {
+                try {
+                    sites.push(this.mapDynamoDBItemToSite(parseInt(data[i]["siteId"].S), data[i]));
+                } catch (error) {
+                    console.error('Error mapping site:', error, data[i]);
+                }
+
+            }
+            return sites;
+        }
+        catch(e) {
+            throw new Error("Unable to get all site data: "+ e)
+        }
+    }
   
     public async postSite(siteData: NewSiteInput) {
         const siteModel = this.PostInputToSiteModel(siteData);

--- a/apps/frontend/src/components/map/Map.tsx
+++ b/apps/frontend/src/components/map/Map.tsx
@@ -31,6 +31,7 @@ const iconGenerators = {
   'Porous Paving': generateDiamondSVG,
   'Tree Trench/Pit': generateStarSVG,
   'Green Roof/Planter': generatePentagonSVG,
+  'Other': generatePentagonSVG // Placeholder, will remove
 } as const;
 
 type SymbolType = keyof typeof iconGenerators;

--- a/apps/frontend/src/pages/mapPage/MapPage.tsx
+++ b/apps/frontend/src/pages/mapPage/MapPage.tsx
@@ -10,6 +10,9 @@ import Tiles from './Tiles';
 
 const icons: string[] = SITE_STATUS_ROADMAP.map((option) => option.image);
 
+
+
+
 export default function MapPage() {
   const [selectedFeatures, setSelectedFeatures] = useState<string[]>([]);
   const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);


### PR DESCRIPTION
ℹ️ Issue
Closes https://www.notion.so/mahekagg/GI-58-Use-get-all-sites-endpoint-to-display-sites-on-map-as-icons-13b8b3e6836e8024a442fb4f693f54e1?pvs=4

📝 Description
Uses the backend to populate the map with all the sites.

Some Notes: 
- There was no get all sites endpoint so I also added that
- My solution does not use any authentication, api call will have to be changed once we implement auth
- I assigned other to the pentagon shape as a placeholder but did not bother adding it to the legend since we plan to make other sites unadoptable

Verification
Here are screenshots of the populated map. With my implementation, any site from the api call that cannot be mapped to a symbol should give a warning. The console did not have this warning.
<img width="1713" alt="Screenshot 2024-11-20 at 2 07 02 PM" src="https://github.com/user-attachments/assets/02ae05c2-5ac7-428e-baa9-3d51314de670">
<img width="1724" alt="Screenshot 2024-11-20 at 2 07 14 PM" src="https://github.com/user-attachments/assets/7e05a91e-5052-46af-b2f2-f1a62b7cec10">


