### PR TITLE
Register form input validation

### DIFF
--- a/apps/frontend/src/pages/registerPage/formPage.tsx
+++ b/apps/frontend/src/pages/registerPage/formPage.tsx
@@ -6,10 +6,13 @@ import {
   Tooltip,
   InputAdornment,
   IconButton,
+  FormHelperText,
 } from '@mui/material';
 import { useState } from 'react';
 import InfoIcon from '@mui/icons-material/Info';
 import { Visibility, VisibilityOff } from '@mui/icons-material';
+import { useFormik } from 'formik';
+import * as Yup from 'yup';
 
 interface FormPageProps {
   setIsSubmitted: (value: boolean) => void;
@@ -26,6 +29,37 @@ const FormPage: React.FC<FormPageProps> = ({ setIsSubmitted }) => {
   const handleToggleRePassword = () => {
     setShowRePassword((prev) => !prev);
   };
+
+  // Validation schema using Yup
+  const validationSchema = Yup.object({
+    userId: Yup.string().required('User ID is required'),
+    email: Yup.string()
+      .email('Enter a valid email address')
+      .required('Email is required'),
+    password: Yup.string().required('Password is required'),
+    rePassword: Yup.string()
+      .required('Please confirm your password')
+      .oneOf([Yup.ref('password')], 'Passwords must match'),
+  });
+
+  // Initialize formik
+  const formik = useFormik({
+    initialValues: {
+      userId: '',
+      email: '',
+      password: '',
+      rePassword: '',
+    },
+    validationSchema: validationSchema,
+    onSubmit: (values) => {
+      // Handle form submission
+      console.log('Form submitted:', values);
+      setIsSubmitted(true);
+    },
+  });
+
+  // Check if all fields are valid
+  const isFormValid = formik.isValid && Object.keys(formik.touched).length === 4;
 
   return (
     <>
@@ -50,7 +84,7 @@ const FormPage: React.FC<FormPageProps> = ({ setIsSubmitted }) => {
       >
         Volunteer Registration
       </h1>
-      <form>
+      <form onSubmit={formik.handleSubmit}>
         <Box
           display="flex"
           alignItems="center"
@@ -85,6 +119,11 @@ const FormPage: React.FC<FormPageProps> = ({ setIsSubmitted }) => {
           fullWidth
           margin="none"
           size="small"
+          name="userId"
+          value={formik.values.userId}
+          onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
+          error={formik.touched.userId && Boolean(formik.errors.userId)}
           InputLabelProps={{
             style: { fontFamily: 'Montserrat', fontWeight: 600 },
           }}
@@ -92,13 +131,28 @@ const FormPage: React.FC<FormPageProps> = ({ setIsSubmitted }) => {
             '& .MuiFilledInput-root': { fontFamily: 'Montserrat' },
           }}
         />
+        {formik.touched.userId && formik.errors.userId && (
+          <FormHelperText 
+            error 
+            sx={{ 
+              fontFamily: 'Montserrat',
+              fontSize: '14px',
+              fontWeight: '500',
+              marginLeft: '2px',
+              marginTop: '4px'
+            }}
+          >
+            {formik.errors.userId}
+          </FormHelperText>
+        )}
+
         <Text
           fontFamily="Montserrat"
           fontSize="20px"
           fontWeight="600"
           lineHeight="24x"
           marginBottom={1}
-          marginTop={20}
+          marginTop={2}
         >
           Email
         </Text>
@@ -108,6 +162,11 @@ const FormPage: React.FC<FormPageProps> = ({ setIsSubmitted }) => {
           fullWidth
           margin="none"
           size="small"
+          name="email"
+          value={formik.values.email}
+          onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
+          error={formik.touched.email && Boolean(formik.errors.email)}
           InputLabelProps={{
             style: { fontFamily: 'Montserrat', fontWeight: 600 },
           }}
@@ -115,13 +174,28 @@ const FormPage: React.FC<FormPageProps> = ({ setIsSubmitted }) => {
             '& .MuiFilledInput-root': { fontFamily: 'Montserrat' },
           }}
         />
+        {formik.touched.email && formik.errors.email && (
+          <FormHelperText 
+            error 
+            sx={{ 
+              fontFamily: 'Montserrat',
+              fontSize: '14px',
+              fontWeight: '500',
+              marginLeft: '2px',
+              marginTop: '4px'
+            }}
+          >
+            {formik.errors.email}
+          </FormHelperText>
+        )}
+
         <Text
           fontFamily="Montserrat"
           fontSize="20px"
           fontWeight="600"
           lineHeight="24x"
           marginBottom={1}
-          marginTop={20}
+          marginTop={2}
         >
           Password
         </Text>
@@ -132,6 +206,11 @@ const FormPage: React.FC<FormPageProps> = ({ setIsSubmitted }) => {
           fullWidth
           margin="none"
           size="small"
+          name="password"
+          value={formik.values.password}
+          onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
+          error={formik.touched.password && Boolean(formik.errors.password)}
           InputLabelProps={{
             style: { fontFamily: 'Montserrat', fontWeight: 600 },
           }}
@@ -148,13 +227,28 @@ const FormPage: React.FC<FormPageProps> = ({ setIsSubmitted }) => {
             '& .MuiFilledInput-root': { fontFamily: 'Montserrat' },
           }}
         />
+        {formik.touched.password && formik.errors.password && (
+          <FormHelperText 
+            error 
+            sx={{ 
+              fontFamily: 'Montserrat',
+              fontSize: '14px',
+              fontWeight: '500',
+              marginLeft: '2px',
+              marginTop: '4px'
+            }}
+          >
+            {formik.errors.password}
+          </FormHelperText>
+        )}
+
         <Text
           fontFamily="Montserrat"
           fontSize="20px"
           fontWeight="600"
           lineHeight="24x"
           marginBottom={1}
-          marginTop={20}
+          marginTop={2}
         >
           Re-enter Password
         </Text>
@@ -165,6 +259,11 @@ const FormPage: React.FC<FormPageProps> = ({ setIsSubmitted }) => {
           fullWidth
           margin="none"
           size="small"
+          name="rePassword"
+          value={formik.values.rePassword}
+          onChange={formik.handleChange}
+          onBlur={formik.handleBlur}
+          error={formik.touched.rePassword && Boolean(formik.errors.rePassword)}
           InputLabelProps={{
             style: { fontFamily: 'Montserrat', fontWeight: 600 },
           }}
@@ -181,27 +280,45 @@ const FormPage: React.FC<FormPageProps> = ({ setIsSubmitted }) => {
             '& .MuiFilledInput-root': { fontFamily: 'Montserrat' },
           }}
         />
+        {formik.touched.rePassword && formik.errors.rePassword && (
+          <FormHelperText 
+            error 
+            sx={{ 
+              fontFamily: 'Montserrat',
+              fontSize: '14px',
+              fontWeight: '500',
+              marginLeft: '2px',
+              marginTop: '4px'
+            }}
+          >
+            {formik.errors.rePassword}
+          </FormHelperText>
+        )}
+
+        <Button
+          type="submit"
+          variant="contained"
+          disabled={!isFormValid}
+          sx={{
+            backgroundColor: '#0072C4',
+            color: 'white',
+            width: '100%',
+            padding: '10px 0',
+            fontFamily: 'Montserrat',
+            fontSize: '20px',
+            fontWeight: '600',
+            lineHeight: '24x',
+            textTransform: 'none',
+            marginTop: '40px',
+            '&.Mui-disabled': {
+              backgroundColor: '#cccccc',
+              color: '#666666',
+            },
+          }}
+        >
+          Create Account
+        </Button>
       </form>
-      <Button
-        variant="contained"
-        sx={{
-          backgroundColor: '#0072C4',
-          color: 'white',
-          width: '100%',
-          padding: '10px 0',
-          fontFamily: 'Montserrat',
-          fontSize: '20px',
-          fontWeight: '600',
-          lineHeight: '24x',
-          textTransform: 'none',
-          marginTop: '40px',
-        }}
-        onClick={() => {
-          setIsSubmitted(true);
-        }}
-      >
-        Create Account
-      </Button>
     </>
   );
 };


### PR DESCRIPTION
Tested on localhost and it worked fine, but I needed to manually put in the route /register, I don't think we have a way to get there right now.

![image](https://github.com/user-attachments/assets/dd73fe7f-5d90-4700-92f5-b87289263b78)
Error messages for invalid input

![image](https://github.com/user-attachments/assets/f93fba19-dead-488c-a3c6-e8c88a0c94f5)
Enabled create account button when all input is validated

