### PR TITLE
Add logic to send rejection email when setting application to rejected

### DIFF
--- a/apps/backend/src/applications/applications.controller.ts
+++ b/apps/backend/src/applications/applications.controller.ts
@@ -12,6 +12,8 @@ import { ApplicationsService } from './applications.service';
 import { ApplicationsModel } from './applications.model';
 import { ApplicationStatus } from './applications.model';
 import { NewApplicationInput } from '../dtos/newApplicationsDTO';
+import { ApiQuery, ApiTags } from '@nestjs/swagger';
+
 
 @Controller('applications')
 export class ApplicationsController {
@@ -35,6 +37,12 @@ export class ApplicationsController {
   }
 
   @Put('editApplication/:appId')
+  @ApiQuery({
+    name: 'applicationStatus',
+    enum: ApplicationStatus,
+    required: true,
+    description: 'The new status to set for the application',
+  })
   public async changeApplicationStatus(
     @Param('appId') appId: number,
     @Query('applicationStatus') appStatus: ApplicationStatus,

--- a/apps/backend/src/applications/applications.service.ts
+++ b/apps/backend/src/applications/applications.service.ts
@@ -97,7 +97,24 @@ export class ApplicationsService {
           emailData,
         );
         console.log('Lambda result: ', lambdaResult);
-      }
+      } else if (appStatus === ApplicationStatus.DENIED) {
+        const user = await this.userService.getUser(application.userId.N);
+        const site = await this.siteService.getSite(application.siteId.N);
+        const name = user.firstName;
+        const email = user.email;
+        const siteName = site.siteName;
+
+        const emailData = {
+          firstName: name,
+          userEmail: email,
+          siteName: siteName,
+        };
+        const lambdaResult = await this.lambdaService.invokeLambda(
+          'giSendApplicationDenied',
+          emailData,
+        );
+        console.log('Lambda result: ', lambdaResult);
+      } 
       return this.mapDynamoDBItemToApplication(updatedApplication);
     } catch (e) {
       throw new Error('Unable to update application status: ' + e);


### PR DESCRIPTION
Sorry write before demo day so this PR is rushed. I added logic to invoke the rejection email lambda when an application is changed to rejected. I tested it:

<img width="1421" alt="Screenshot 2025-04-16 at 5 56 35 PM" src="https://github.com/user-attachments/assets/ab70bb8c-fb0e-4b52-9b7e-e78876dd7d75" />
<img width="1074" alt="Screenshot 2025-04-16 at 5 52 52 PM" src="https://github.com/user-attachments/assets/de615c23-56ac-4c05-9f78-58aee3dc1335" />
<img width="1364" alt="Screenshot 2025-04-16 at 5 53 40 PM" src="https://github.com/user-attachments/assets/7517439f-f8ea-40e6-abc8-7b61ec9e4ea9" />
<img width="512" alt="Screenshot 2025-04-16 at 5 53 52 PM" src="https://github.com/user-attachments/assets/cd6d63bf-df2a-443b-b4df-bd8d36834e81" />
